### PR TITLE
PFA-128 fix empty income and expense records crashing the page

### DIFF
--- a/frontend/src/components/Expense/ExpenseTable.tsx
+++ b/frontend/src/components/Expense/ExpenseTable.tsx
@@ -17,7 +17,7 @@ interface ExpenseTableProps {
 }
 
 const ExpenseTable: React.FC<ExpenseTableProps> = ({
-  expenses,
+  expenses = [], // Default to empty array if undefined/null
   loading,
   onEdit,
   onDelete,

--- a/frontend/src/components/Income/IncomeTable.tsx
+++ b/frontend/src/components/Income/IncomeTable.tsx
@@ -17,7 +17,7 @@ interface IncomeTableProps {
 }
 
 const IncomeTable: React.FC<IncomeTableProps> = ({
-  incomes,
+  incomes = [], // Default to empty array if undefined/null
   loading,
   onEdit,
   onDelete,


### PR DESCRIPTION
This pull request introduces a minor improvement to the expense and income table components by ensuring both handle missing data gracefully. Specifically, it sets default values for the `expenses` and `incomes` props to prevent potential runtime errors.

* Defaulted the `expenses` prop to an empty array in `ExpenseTable`, ensuring the component works even if no expenses are provided. (`frontend/src/components/Expense/ExpenseTable.tsx`)
* Defaulted the `incomes` prop to an empty array in `IncomeTable`, ensuring the component works even if no incomes are provided. (`frontend/src/components/Income/IncomeTable.tsx`)